### PR TITLE
Add slack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ This gives an overview of all the features of `ff_bot`
 
 - BOT_ID: This is your Bot ID from the GroupMe developers page (REQUIRED)
 - LEAGUE_ID: This is your ESPN league id (REQUIRED)
-- START_DATE: This is when the bot will start paying attention and sending messages to GroupMe. (2017-09-05 by default)
-- END_DATE: This is when the bot will stop paying attention and stop sending messages to GroupMe. (2017-12-26 by default)
-- LEAGUE_YEAR: ESPN League year to look at (2017 by default)
+- START_DATE: This is when the bot will start paying attention and sending messages to GroupMe. (2018-09-05 by default)
+- END_DATE: This is when the bot will stop paying attention and stop sending messages to GroupMe. (2018-12-26 by default)
+- LEAGUE_YEAR: ESPN League year to look at (2018 by default)
 - TIMEZONE: The timezone that the messages will look to send in. (America/New_York by default)
 - INIT_MSG: The message that the bot will say when it is started (“Hai” by default, can be blank for no message)
 
@@ -155,9 +155,9 @@ Note: App will restart when you change any variable so your chat room may be sem
 
 - BOT_ID: This is your Bot ID from the GroupMe developers page (REQUIRED)
 - LEAGUE_ID: This is your ESPN league id (REQUIRED)
-- START_DATE: This is when the bot will start paying attention and sending messages to GroupMe. (2017-09-05 by default)
-- END_DATE: This is when the bot will stop paying attention and stop sending messages to GroupMe. (2017-12-26 by default)
-- LEAGUE_YEAR: ESPN League year to look at (2017 by default)
+- START_DATE: This is when the bot will start paying attention and sending messages to GroupMe. (2018-09-05 by default)
+- END_DATE: This is when the bot will stop paying attention and stop sending messages to GroupMe. (2018-12-26 by default)
+- LEAGUE_YEAR: ESPN League year to look at (2018 by default)
 - TIMEZONE: The timezone that the messages will look to send in. (America/New_York by default)
 - INIT_MSG: The message that the bot will say when it is started (“Hai” by default, can be blank for no message)
 

--- a/README.md
+++ b/README.md
@@ -147,13 +147,6 @@ Go to https://api.slack.com/apps/new
 
 Name the app, and choose the intended workspace from the dropdown.
 
-///Select the Bot Users section on the side.
-
-![](https://i.imgur.com/pGy6xvK.png)
-
-Select Add a Bot User, set the display name and username, choose if you want
-to show the bot as always offline or not, and then press Add Bot User.///
-
 Select the Incoming Webhooks section on the side.
 
 ![](https://i.imgur.com/ziRQCVP.png)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Shoutout to /u/rbart65 on reddit and rbarton65 on github for creating the origin
 
 # ESPN Fantasy Football GroupMe Bot
 
-This package creates a docker container that runs a GroupMe chat bot to send 
-ESPN Fantasy Football information to a GroupMe chat room.
+This package creates a docker container that runs a GroupMe or Slack chat bot to send
+ESPN Fantasy Football information to a GroupMe or Slack chat room.
 
 **What does this do?**
 
@@ -24,7 +24,7 @@ ESPN Fantasy Football information to a GroupMe chat room.
 
 ## Getting Started
 
-These instructions will get you a copy of the project up and running 
+These instructions will get you a copy of the project up and running
 on your local machine for development and testing purposes.
 
 ### Installing
@@ -54,18 +54,22 @@ This gives an overview of all the features of `ff_bot`
 
 ### Environment Variables
 
-- BOT_ID: This is your Bot ID from the GroupMe developers page (REQUIRED)
+- BOT_ID: This is your Bot ID from the GroupMe developers page (REQUIRED IF USING GROUPME)
+- WEBHOOK_URL: This is your Webhook URL from the Slack App page (REQUIRED IF USING SLACK)
 - LEAGUE_ID: This is your ESPN league id (REQUIRED)
-- START_DATE: This is when the bot will start paying attention and sending messages to GroupMe. (2018-09-05 by default)
-- END_DATE: This is when the bot will stop paying attention and stop sending messages to GroupMe. (2018-12-26 by default)
+- START_DATE: This is when the bot will start paying attention and sending messages to GroupMe or Slack. (2018-09-05 by default)
+- END_DATE: This is when the bot will stop paying attention and stop sending messages to GroupMe or Slack. (2018-12-26 by default)
 - LEAGUE_YEAR: ESPN League year to look at (2018 by default)
 - TIMEZONE: The timezone that the messages will look to send in. (America/New_York by default)
 - INIT_MSG: The message that the bot will say when it is started (“Hai” by default, can be blank for no message)
 
 ### Running with Docker
 
+Use BOT_ID if using Groupme, and WEBHOOK_URL if using Slack (or both to get messages in both places)
+
 ```bash
 >>> export BOT_ID=[enter your GroupMe Bot ID]
+>>> export WEBHOOK_URL=[enter your Webhook URL]
 >>> export LEAGUE_ID=[enter ESPN league ID]
 >>> export LEAGUE_YEAR=[enter league year]
 >>> cd ff_bot
@@ -78,8 +82,11 @@ ff_bot
 
 ### Running without Docker
 
+Use BOT_ID if using Groupme, and WEBHOOK_URL if using Slack (or both to get messages in both places)
+
 ```bash
 >>> export BOT_ID=[enter your GroupMe Bot ID]
+>>> export WEBHOOK_URL=[enter your Webhook URL]
 >>> export LEAGUE_ID=[enter ESPN league ID]
 >>> export LEAGUE_YEAR=[enter league year]
 >>> cd ff_bot
@@ -95,7 +102,7 @@ you can run these tests by changing the directory to the `ff_bot` directory and 
 python3 setup.py test
 ```
 
-## Setting up GroupMe, and deploying app in Heroku
+## Setting up GroupMe or Slack, and deploying app in Heroku
 
 **Do not deploy 2 of the same bot in the same chat. In general, you should let your commissioner do the setup**
 
@@ -128,6 +135,42 @@ Side note: If you use the bot id depicted in the page you will spam an empty cha
 
 ![](https://i.imgur.com/k65EZFJ.png)
 
+### Slack setup
+
+Go to https://slack.com/signin and sign in to the workspace the bot will be in
+
+If you don't have one for your league already, create a new League Channel
+
+Next we will setup the bot for Slack
+
+Go to https://api.slack.com/apps/new
+
+Name the app, and choose the intended workspace from the dropdown.
+
+///Select the Bot Users section on the side.
+
+![](https://i.imgur.com/pGy6xvK.png)
+
+Select Add a Bot User, set the display name and username, choose if you want
+to show the bot as always offline or not, and then press Add Bot User.///
+
+Select the Incoming Webhooks section on the side.
+
+![](https://i.imgur.com/ziRQCVP.png)
+
+Change the toggle from Off to On.
+
+Select Add New Webhook to Workspace
+
+![](https://i.imgur.com/tJRRrfz.png)
+
+In the Post to dropdown, select the channel you want to send messages to, then
+select Authorize.
+
+This page is important as you will need the "Webhook URL" on this page.
+
+![](https://i.imgur.com/mmzhDS0.png)
+
 ### Heroku setup
 
 Heroku is what we will be using to host the chat bot (for free)
@@ -153,10 +196,11 @@ Now you will need to setup your environment variables so that it works for your 
 Now we will need to edit these variables (click the pencil to the right of the variable to modify)
 Note: App will restart when you change any variable so your chat room may be semi-spammed with the init message of "Hai" you can change the INIT_MSG variable to be blank to have no init message. It should also be noted that Heroku seems to restart the app about once a day
 
-- BOT_ID: This is your Bot ID from the GroupMe developers page (REQUIRED)
+- BOT_ID: This is your Bot ID from the GroupMe developers page (REQUIRED IF USING GROUPME)
+- WEBHOOK_URL: This is your Webhook URL from the Slack App page (REQUIRED IF USING SLACK)
 - LEAGUE_ID: This is your ESPN league id (REQUIRED)
-- START_DATE: This is when the bot will start paying attention and sending messages to GroupMe. (2018-09-05 by default)
-- END_DATE: This is when the bot will stop paying attention and stop sending messages to GroupMe. (2018-12-26 by default)
+- START_DATE: This is when the bot will start paying attention and sending messages to GroupMe or Slack. (2018-09-05 by default)
+- END_DATE: This is when the bot will stop paying attention and stop sending messages to GroupMe or Slack. (2018-12-26 by default)
 - LEAGUE_YEAR: ESPN League year to look at (2018 by default)
 - TIMEZONE: The timezone that the messages will look to send in. (America/New_York by default)
 - INIT_MSG: The message that the bot will say when it is started (“Hai” by default, can be blank for no message)
@@ -165,6 +209,6 @@ After you have setup your variables you will need to turn it on. Navigate to the
 You should see something like below. Click the pencil on the right and toggle the buton so it is blue like depicted and click "Confirm."
 ![](https://i.imgur.com/J6bpV2I.png)
 
-You're done! You now have a fully featured GroupMe chat bot for ESPN leagues! If you have an INIT_MSG you will see it exclaimed in your GroupMe chat room.
+You're done! You now have a fully featured GroupMe/Slack chat bot for ESPN leagues! If you have an INIT_MSG you will see it exclaimed in your GroupMe or Slack chat room.
 
 Unfortunately to do auto deploys of the latest version you need admin access to the repository on git. You can check for updates on the github page (https://github.com/dtcarls/ff_bot/commits/master) and click the deploy button again; however, this will deploy a new instance and the variables will need to be edited again.

--- a/app.json
+++ b/app.json
@@ -38,6 +38,6 @@
     "INIT_MSG": {
       "description": "Bot Init Message",
       "value": "Hi"
-    },
+    }
   }
 }

--- a/app.json
+++ b/app.json
@@ -15,6 +15,10 @@
       "description": "GroupMe Bot ID",
       "value": "1"
     },
+    "WEBHOOK_URL": {
+      "description": "Slack Webhook URL",
+      "value": "1"
+    },
     "LEAGUE_ID": {
       "description": "ESPN League ID",
       "value": "1"

--- a/app.json
+++ b/app.json
@@ -21,7 +21,7 @@
     },
     "LEAGUE_YEAR": {
       "description": "ESPN League Year",
-      "value": "2017"
+      "value": "2018"
     },
     "TIMEZONE": {
       "description": "League timezone for sending messages",
@@ -29,11 +29,11 @@
     },
     "START_DATE": {
       "description": "Season Start Date",
-      "value": "2017-09-05"
+      "value": "2018-09-05"
     },
     "END_DATE": {
       "description": "Season End Date",
-      "value": "2017-12-26"
+      "value": "2018-12-26"
     },
     "INIT_MSG": {
       "description": "Bot Init Message",

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -295,7 +295,7 @@ if __name__ == '__main__':
     #score update:                       sunday at 1pm, 4pm, 8pm.
 
     sched.add_job(bot_main, 'cron', ['get_power_rankings'], id='power_rankings',
-        day_of_week='mon', hour=19, minute=59, start_date=ff_start_date, end_date=ff_end_date,
+        day_of_week='tue', hour=18, minute=30, start_date=ff_start_date, end_date=ff_end_date,
         timezone=myTimezone, replace_existing=True)
     sched.add_job(bot_main, 'cron', ['get_matchups'], id='matchups',
         day_of_week='thu', hour=19, minute=30, start_date=ff_start_date, end_date=ff_end_date,

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -10,6 +10,7 @@ class GroupMeException(Exception):
     pass
 
 class SlackException(Exception):
+    pass
 
 class GroupMeBot(object):
     #Creates GroupMe Bot to send messages
@@ -29,7 +30,7 @@ class GroupMeBot(object):
 
         headers = {'content-type': 'application/json'}
 
-        if self.bot_id != 1:
+        if self.bot_id != "1":
             r = requests.post("https://api.groupme.com/v3/bots/post",
                               data=json.dumps(template), headers=headers)
             if r.status_code != 202:
@@ -47,13 +48,14 @@ class SlackBot(object):
 
     def send_message(self, text):
         #Sends a message to the chatroom
+        message = "```{0}```".format(text)
         template = {
-                    "text":"Hello, World!"
+                    "text":message
                     }
 
         headers = {'content-type': 'application/json'}
 
-        if self.webhook_url != 1:
+        if self.webhook_url != "1":
             r = requests.post(self.webhook_url,
                               data=json.dumps(template), headers=headers)
 
@@ -293,7 +295,7 @@ if __name__ == '__main__':
     #score update:                       sunday at 1pm, 4pm, 8pm.
 
     sched.add_job(bot_main, 'cron', ['get_power_rankings'], id='power_rankings',
-        day_of_week='mon', hour=19, minute=47, start_date=ff_start_date, end_date=ff_end_date,
+        day_of_week='mon', hour=19, minute=59, start_date=ff_start_date, end_date=ff_end_date,
         timezone=myTimezone, replace_existing=True)
     sched.add_job(bot_main, 'cron', ['get_matchups'], id='matchups',
         day_of_week='thu', hour=19, minute=30, start_date=ff_start_date, end_date=ff_end_date,

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -173,7 +173,7 @@ def bot_main(function):
     try:
         year = os.environ["LEAGUE_YEAR"]
     except KeyError:
-        year=2017
+        year=2018
 
     bot = GroupMeBot(bot_id)
     league = League(league_id, year)
@@ -230,12 +230,12 @@ if __name__ == '__main__':
     try:
         ff_start_date = os.environ["START_DATE"]
     except KeyError:
-        ff_start_date='2017-09-05'
+        ff_start_date='2018-09-05'
 
     try:
         ff_end_date = os.environ["END_DATE"]
     except KeyError:
-        ff_end_date='2017-12-26'
+        ff_end_date='201-12-26'
 
     try:
         myTimezone = os.environ["TIMEZONE"]

--- a/ff_bot/tests/test_slackbot.py
+++ b/ff_bot/tests/test_slackbot.py
@@ -25,5 +25,5 @@ class SlackTestCase(unittest.TestCase):
     def test_bad_bot_id(self, m):
         '''Does the expected error raise when a bot id is incorrect?'''
         m.post(self.url, status_code=404)
-        with self.assertRaises(GroupMeException):
+        with self.assertRaises(SlackException):
             self.test_bot.send_message(self.test_text)

--- a/ff_bot/tests/test_slackbot.py
+++ b/ff_bot/tests/test_slackbot.py
@@ -12,7 +12,7 @@ class SlackTestCase(unittest.TestCase):
 
     def setUp(self):
         self.url = "https://hooks.slack.com/services/A1B2C3/ABC1ABC2/abcABC1abcABC2"
-        self.test_bot = SlackBot(url)
+        self.test_bot = SlackBot(self.url)
         self.test_text = "This is a test."
 
     @requests_mock.Mocker()

--- a/ff_bot/tests/test_slackbot.py
+++ b/ff_bot/tests/test_slackbot.py
@@ -1,0 +1,29 @@
+import unittest
+
+
+import requests_mock
+
+
+from ff_bot.ff_bot import (SlackBot, SlackException, )
+
+
+class SlackTestCase(unittest.TestCase):
+    '''Test SlackBot class'''
+
+    def setUp(self):
+        self.url = "https://hooks.slack.com/services/A1B2C3/ABC1ABC2/abcABC1abcABC2"
+        self.test_bot = SlackBot(url)
+        self.test_text = "This is a test."
+
+    @requests_mock.Mocker()
+    def test_send_message(self, m):
+        '''Does the message send successfully?'''
+        m.post(self.url, status_code=200)
+        self.assertEqual(self.test_bot.send_message(self.test_text).status_code, 200)
+
+    @requests_mock.Mocker()
+    def test_bad_bot_id(self, m):
+        '''Does the expected error raise when a bot id is incorrect?'''
+        m.post(self.url, status_code=404)
+        with self.assertRaises(GroupMeException):
+            self.test_bot.send_message(self.test_text)


### PR DESCRIPTION
Allows you to add a slack workspace and channel by adding a webhook integration on the slack API website.

You add the webhook url as an environment variable. If both the GroupMe bot ID and the Slack Webhook URL are set, it will send the same message to both Slack and GroupMe. If one or both of them is/are left as "1" by default it won't send a message to that chat.