### PR TITLE
Add discord support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Shoutout to /u/rbart65 on reddit and rbarton65 on github for creating the origin
 
 # ESPN Fantasy Football GroupMe Bot
 
-This package creates a docker container that runs a GroupMe or Slack chat bot to send
-ESPN Fantasy Football information to a GroupMe or Slack chat room.
+This package creates a docker container that runs a GroupMe, Discord, or Slack chat bot to send
+ESPN Fantasy Football information to a GroupMe, Discord or Slack chat room.
 
 **What does this do?**
 
@@ -55,17 +55,18 @@ This gives an overview of all the features of `ff_bot`
 ### Environment Variables
 
 - BOT_ID: This is your Bot ID from the GroupMe developers page (REQUIRED IF USING GROUPME)
-- WEBHOOK_URL: This is your Webhook URL from the Slack App page (REQUIRED IF USING SLACK)
+- SLACK_WEBHOOK_URL: This is your Webhook URL from the Slack App page (REQUIRED IF USING SLACK)
+- DISCORD_WEBHOOK_URL: This is your Webhook URL from the Discord Settings page (REQUIRED IF USING DISCORD)
 - LEAGUE_ID: This is your ESPN league id (REQUIRED)
-- START_DATE: This is when the bot will start paying attention and sending messages to GroupMe or Slack. (2018-09-05 by default)
-- END_DATE: This is when the bot will stop paying attention and stop sending messages to GroupMe or Slack. (2018-12-26 by default)
+- START_DATE: This is when the bot will start paying attention and sending messages to your chat. (2018-09-05 by default)
+- END_DATE: This is when the bot will stop paying attention and stop sending messages to your chat. (2018-12-26 by default)
 - LEAGUE_YEAR: ESPN League year to look at (2018 by default)
 - TIMEZONE: The timezone that the messages will look to send in. (America/New_York by default)
 - INIT_MSG: The message that the bot will say when it is started (“Hai” by default, can be blank for no message)
 
 ### Running with Docker
 
-Use BOT_ID if using Groupme, and WEBHOOK_URL if using Slack (or both to get messages in both places)
+Use BOT_ID if using Groupme, DISCORD_WEBHOOK_URL if using Discord, and SLACK_WEBHOOK_URL if using Slack (or multiple to get messages in multiple places)
 
 ```bash
 >>> export BOT_ID=[enter your GroupMe Bot ID]
@@ -82,7 +83,7 @@ ff_bot
 
 ### Running without Docker
 
-Use BOT_ID if using Groupme, and WEBHOOK_URL if using Slack (or both to get messages in both places)
+Use BOT_ID if using Groupme, DISCORD_WEBHOOK_URL if using Discord, and SLACK_WEBHOOK_URL if using Slack (or multiple to get messages in multiple places)
 
 ```bash
 >>> export BOT_ID=[enter your GroupMe Bot ID]
@@ -102,7 +103,7 @@ you can run these tests by changing the directory to the `ff_bot` directory and 
 python3 setup.py test
 ```
 
-## Setting up GroupMe or Slack, and deploying app in Heroku
+## Setting up GroupMe, Discord, or Slack, and deploying app in Heroku
 
 **Do not deploy 2 of the same bot in the same chat. In general, you should let your commissioner do the setup**
 
@@ -164,6 +165,20 @@ This page is important as you will need the "Webhook URL" on this page.
 
 ![](https://i.imgur.com/mmzhDS0.png)
 
+### Discord setup
+
+Log into or create a discord account
+
+Go to or create a discord server to receive messages in
+
+Open the server settings
+
+Go to Webhooks
+
+Create a webhook, give it a name and pick which channel to receive messages in
+
+Save the "Webhook URL" on this page
+
 ### Heroku setup
 
 Heroku is what we will be using to host the chat bot (for free)
@@ -190,10 +205,11 @@ Now we will need to edit these variables (click the pencil to the right of the v
 Note: App will restart when you change any variable so your chat room may be semi-spammed with the init message of "Hai" you can change the INIT_MSG variable to be blank to have no init message. It should also be noted that Heroku seems to restart the app about once a day
 
 - BOT_ID: This is your Bot ID from the GroupMe developers page (REQUIRED IF USING GROUPME)
-- WEBHOOK_URL: This is your Webhook URL from the Slack App page (REQUIRED IF USING SLACK)
+- SLACK_WEBHOOK_URL: This is your Webhook URL from the Slack App page (REQUIRED IF USING SLACK)
+- DISCORD_WEBHOOK_URL: This is your Webhook URL from the Discord Settings page (REQUIRED IF USING DISCORD)
 - LEAGUE_ID: This is your ESPN league id (REQUIRED)
-- START_DATE: This is when the bot will start paying attention and sending messages to GroupMe or Slack. (2018-09-05 by default)
-- END_DATE: This is when the bot will stop paying attention and stop sending messages to GroupMe or Slack. (2018-12-26 by default)
+- START_DATE: This is when the bot will start paying attention and sending messages to your chat. (2018-09-05 by default)
+- END_DATE: This is when the bot will stop paying attention and stop sending messages to your chat. (2018-12-26 by default)
 - LEAGUE_YEAR: ESPN League year to look at (2018 by default)
 - TIMEZONE: The timezone that the messages will look to send in. (America/New_York by default)
 - INIT_MSG: The message that the bot will say when it is started (“Hai” by default, can be blank for no message)
@@ -202,7 +218,7 @@ After you have setup your variables you will need to turn it on. Navigate to the
 You should see something like below. Click the pencil on the right and toggle the buton so it is blue like depicted and click "Confirm."
 ![](https://i.imgur.com/J6bpV2I.png)
 
-You're done! You now have a fully featured GroupMe/Slack chat bot for ESPN leagues! If you have an INIT_MSG you will see it exclaimed in your GroupMe or Slack chat room.
+You're done! You now have a fully featured GroupMe/Slack/Discord chat bot for ESPN leagues! If you have an INIT_MSG you will see it exclaimed in your GroupMe, Discord, or Slack chat room.
 
 Unfortunately to do auto deploys of the latest version you need admin access to the repository on git. You can check for updates on the github page (https://github.com/dtcarls/ff_bot/commits/master) and click the deploy button again; however, this will deploy a new instance and the variables will need to be edited again.
 

--- a/README.md
+++ b/README.md
@@ -173,11 +173,19 @@ Go to or create a discord server to receive messages in
 
 Open the server settings
 
+![](https://i.imgur.com/bDk2ttJ.png)
+
 Go to Webhooks
+
+![](https://i.imgur.com/mfFHGbT.png)
 
 Create a webhook, give it a name and pick which channel to receive messages in
 
+![](https://i.imgur.com/NAJLv6D.png)
+
 Save the "Webhook URL" on this page
+
+![](https://i.imgur.com/U4MKZSY.png)
 
 ### Heroku setup
 

--- a/README.md
+++ b/README.md
@@ -205,3 +205,9 @@ You should see something like below. Click the pencil on the right and toggle th
 You're done! You now have a fully featured GroupMe/Slack chat bot for ESPN leagues! If you have an INIT_MSG you will see it exclaimed in your GroupMe or Slack chat room.
 
 Unfortunately to do auto deploys of the latest version you need admin access to the repository on git. You can check for updates on the github page (https://github.com/dtcarls/ff_bot/commits/master) and click the deploy button again; however, this will deploy a new instance and the variables will need to be edited again.
+
+Like the bot? Consider making a donation
+------
+* BTC: 3C8SEcDh52iDSYQY55kwELrNWoQRMkXLCR
+* ETH: 0xA098c4e8CC1c12422d5B34d6454133190CDdCAC3
+* LTC: MHx74YbrHE592ePBbdQ4cL9ZQC15xaAjtM

--- a/app.json
+++ b/app.json
@@ -21,7 +21,7 @@
     },
     "LEAGUE_YEAR": {
       "description": "ESPN League Year",
-      "value": "2017"
+      "value": "2018"
     },
     "TIMEZONE": {
       "description": "League timezone for sending messages",
@@ -29,11 +29,11 @@
     },
     "START_DATE": {
       "description": "Season Start Date",
-      "value": "2017-09-05"
+      "value": "2018-09-05"
     },
     "END_DATE": {
       "description": "Season End Date",
-      "value": "2017-12-26"
+      "value": "2018-12-26"
     },
     "INIT_MSG": {
       "description": "Bot Init Message",

--- a/app.json
+++ b/app.json
@@ -15,8 +15,12 @@
       "description": "GroupMe Bot ID",
       "value": "1"
     },
-    "WEBHOOK_URL": {
+    "SLACK_WEBHOOK_URL": {
       "description": "Slack Webhook URL",
+      "value": "1"
+    },
+    "DISCORD_WEBHOOK_URL": {
+      "description": "Discord Webhook URL",
       "value": "1"
     },
     "LEAGUE_ID": {

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -12,6 +12,9 @@ class GroupMeException(Exception):
 class SlackException(Exception):
     pass
 
+class DiscordException(Exception):
+    pass
+
 class GroupMeBot(object):
     #Creates GroupMe Bot to send messages
     def __init__(self, bot_id):
@@ -61,6 +64,32 @@ class SlackBot(object):
 
             if r.status_code != 200:
                 raise SlackException('WEBHOOK_URL')
+
+            return r
+
+class DiscordBot(object):
+    #Creates Discord Bot to send messages
+    def __init__(self, webhook_url):
+        self.webhook_url = webhook_url
+
+    def __repr__(self):
+        return "Discord Webhook Url(%s)" % self.webhook_url
+
+    def send_message(self, text):
+        #Sends a message to the chatroom
+        message = "```{0}```".format(text)
+        template = {
+                    "content":message
+                    }
+
+        headers = {'content-type': 'application/json'}
+
+        if self.webhook_url not in (1, "1"):
+            r = requests.post(self.webhook_url,
+                              data=json.dumps(template), headers=headers)
+
+            if r.status_code != 204:
+                raise DiscordException('WEBHOOK_URL')
 
             return r
 
@@ -204,9 +233,14 @@ def bot_main(function):
         bot_id = 1
 
     try:
-        webhook_url = os.environ["WEBHOOK_URL"]
+        slack_webhook_url = os.environ["SLACK_WEBHOOK_URL"]
     except KeyError:
-        webhook_url = 1
+        slack_webhook_url = 1
+
+    try:
+        discord_webhook_url = os.environ["DISCORD_WEBHOOK_URL"]
+    except KeyError:
+        discord_webhook_url = 1
 
     league_id = os.environ["LEAGUE_ID"]
 
@@ -216,7 +250,8 @@ def bot_main(function):
         year=2018
 
     bot = GroupMeBot(bot_id)
-    slack_bot = SlackBot(webhook_url)
+    slack_bot = SlackBot(slack_webhook_url)
+    discord_bot = DiscrodBot(discord_webhook_url)
     league = League(league_id, year)
 
     test = False
@@ -231,31 +266,38 @@ def bot_main(function):
         #bot.send_message(get_trophies(league))
         bot.send_message("test complete")
         slack_bot.send_message("test complete")
+        discord_bot.send_message("test complete")
 
     if function=="get_matchups":
         text = get_matchups(league)
         bot.send_message(text)
         slack_bot.send_message(text)
+        discord_bot.send_message(text)
     elif function=="get_scoreboard":
         text = get_scoreboard(league)
         bot.send_message(text)
         slack_bot.send_message(text)
+        discord_bot.send_message(text)
     elif function=="get_scoreboard_short":
         text = get_scoreboard_short(league)
         bot.send_message(text)
         slack_bot.send_message(text)
+        discord_bot.send_message(text)
     elif function=="get_close_scores":
         text = get_close_scores(league)
         bot.send_message(text)
         slack_bot.send_message(text)
+        discord_bot.send_message(text)
     elif function=="get_power_rankings":
         text = get_power_rankings(league)
         bot.send_message(text)
         slack_bot.send_message(text)
+        discord_bot.send_message(text)
     elif function=="get_trophies":
         text = get_trophies(league)
         bot.send_message(text)
         slack_bot.send_message(text)
+        discord_bot.send_message(text)
     elif function=="get_final":
         text = "Final " + get_scoreboard_short(league, True)
         text = text + "\n\n" + get_trophies(league)
@@ -264,11 +306,13 @@ def bot_main(function):
         else:
             bot.send_message(text)
             slack_bot.send_message(text)
+            discord_bot.send_message(text)
     elif function=="init":
         try:
             text = os.environ["INIT_MSG"]
             bot.send_message(text)
             slack_bot.send_message(text)
+            discord_bot.send_message(text)
         except KeyError:
             #do nothing here, empty init message
             pass
@@ -276,6 +320,7 @@ def bot_main(function):
         text = "Something happened. HALP"
         bot.send_message(text)
         slack_bot.send_message(text)
+        discord_bot.send_message(text)
 
 
 if __name__ == '__main__':

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -235,7 +235,7 @@ if __name__ == '__main__':
     try:
         ff_end_date = os.environ["END_DATE"]
     except KeyError:
-        ff_end_date='201-12-26'
+        ff_end_date='2018-12-26'
 
     try:
         myTimezone = os.environ["TIMEZONE"]

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -251,7 +251,7 @@ def bot_main(function):
 
     bot = GroupMeBot(bot_id)
     slack_bot = SlackBot(slack_webhook_url)
-    discord_bot = DiscrodBot(discord_webhook_url)
+    discord_bot = DiscordBot(discord_webhook_url)
     league = League(league_id, year)
 
     test = False

--- a/ff_bot/tests/test_discordbot.py
+++ b/ff_bot/tests/test_discordbot.py
@@ -19,7 +19,7 @@ class DiscordTestCase(unittest.TestCase):
     def test_send_message(self, m):
         '''Does the message send successfully?'''
         m.post(self.url, status_code=204)
-        self.assertEqual(self.test_bot.send_message(self.test_text).status_code, 200)
+        self.assertEqual(self.test_bot.send_message(self.test_text).status_code, 204)
 
     @requests_mock.Mocker()
     def test_bad_bot_id(self, m):

--- a/ff_bot/tests/test_discordbot.py
+++ b/ff_bot/tests/test_discordbot.py
@@ -1,0 +1,29 @@
+import unittest
+
+
+import requests_mock
+
+
+from ff_bot.ff_bot import (DiscordBot, DiscordException, )
+
+
+class DiscordTestCase(unittest.TestCase):
+    '''Test DiscordBot class'''
+
+    def setUp(self):
+        self.url = "https://discordapp.com/api/webhooks/123/abc"
+        self.test_bot = DiscordBot(self.url)
+        self.test_text = "This is a test."
+
+    @requests_mock.Mocker()
+    def test_send_message(self, m):
+        '''Does the message send successfully?'''
+        m.post(self.url, status_code=204)
+        self.assertEqual(self.test_bot.send_message(self.test_text).status_code, 200)
+
+    @requests_mock.Mocker()
+    def test_bad_bot_id(self, m):
+        '''Does the expected error raise when a bot id is incorrect?'''
+        m.post(self.url, status_code=404)
+        with self.assertRaises(DiscordException):
+            self.test_bot.send_message(self.test_text)


### PR DESCRIPTION
Allows you to add a discord server and channel by adding a webhook integration in the Discord server settings.

You add the webhook url as an environment variable.