### PR TITLE
Update python 3 13

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "description": "Keep Python base image updated within 3.13.x",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["python"],
+      "allowedVersions": "~3.13.0",
+      "groupName": "Python base image"
+    }
+  ]
+}

--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -1,4 +1,4 @@
-name: Publish image on commit or published release
+name: Build image, test it, and publish if it passes
 
 on:
   push:
@@ -15,43 +15,50 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Set tag name for releases
-        if: ${{ github.event_name == 'release' }}
-        run: echo "TAG=ghcr.io/${GITHUB_REPOSITORY,,}:${GITHUB_REF##*/}" >>${GITHUB_ENV}
+      - name: Extract Python version from Dockerfile
+        id: python_version
+        run: |
+          PYTHON_VER=$(grep -oP '^FROM python:\K[0-9]+\.[0-9]+\.[0-9]+' Dockerfile | head -1)
+          echo "PYTHON_VERSION=$PYTHON_VER" >> $GITHUB_ENV
 
-      - name: Set tag name for commits
-        if: ${{ github.event_name == 'push' }}
-        run: echo "TAG=ghcr.io/${GITHUB_REPOSITORY,,}:${{ github.sha }}" >>${GITHUB_ENV}
+      - name: Set Docker image tags
+        run: |
+          IMAGE_BASE="ghcr.io/${GITHUB_REPOSITORY,,}"
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            SHA_TAG="${IMAGE_BASE}:${GITHUB_REF##*/}-python${PYTHON_VERSION}"
+          else
+            SHA_TAG="${IMAGE_BASE}:${GITHUB_SHA}-python${PYTHON_VERSION}"
+          fi
+          LATEST_TAG="${IMAGE_BASE}:latest"
+          echo "TAGS=$SHA_TAG $LATEST_TAG" >> $GITHUB_ENV
 
-      - name: Build image
-        uses: docker/build-push-action@v2
-        with:
-          load: true
-          push: false
-          tags: ${{ env.TAG }}
+      - name: Build Docker image
+        run: docker build -t ${{ env.TAGS }} .
 
       - name: Test image
         run: |
-          docker run ${{ env.TAG }} /bin/sh -c "\
-          python -m pip install --upgrade pip && \
-          pip install -r requirements.txt && \
-          pip install -r requirements-test.txt && \
-          pytest"
+          # Test the first tag (SHA/Python tag)
+          FIRST_TAG=$(echo ${{ env.TAGS }} | awk '{print $1}')
+          docker run --rm $FIRST_TAG /bin/sh -c "\
+            python -m pip install --upgrade pip && \
+            pip install -r requirements-test.txt && \
+            pytest"
 
-      - name: Push image to registry
-        uses: docker/build-push-action@v2
+      - name: Push Docker image
+        uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ${{ env.TAG }}
+          tags: ${{ env.TAGS }}
+          load: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.13
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.13
 
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.9-slim-bullseye
+FROM python:3.13.7-slim-trixie
 
 # Install app
 ADD . /usr/src/gamedaybot


### PR DESCRIPTION
- Update the image to use python 3.13 as a base since it's a stable supported version still in bugfix phase. 
- Update versions of github actions
- Tweak publish workflow so only builds that pass tests actually get pushed
- Add renovate config to get new builds when updates to the base image are published